### PR TITLE
Fix/profiler event count

### DIFF
--- a/tensorflow/lite/micro/kernels/xcore/xcore_extended_interpreter.cc
+++ b/tensorflow/lite/micro/kernels/xcore/xcore_extended_interpreter.cc
@@ -96,7 +96,7 @@ void BufferedErrorReporter::Clear() { log_stream_.str(""); }
 ExtendedXCoreInterpreter::ExtendedXCoreInterpreter(
     const tflite::Model* model, const tflite::MicroOpResolver& resolver,
     uint8_t* arena, size_t arena_size, tflite::ErrorReporter* reporter,
-    bool use_current_thread, tflite::MicroProfiler* profiler)
+    bool use_current_thread, XCoreProfiler* profiler)
     : XCoreInterpreter(model, resolver, arena, arena_size, reporter,
                        use_current_thread, profiler),
       model_(model),
@@ -105,7 +105,7 @@ ExtendedXCoreInterpreter::ExtendedXCoreInterpreter(
 ExtendedXCoreInterpreter::ExtendedXCoreInterpreter(
     const tflite::Model* model, const tflite::MicroOpResolver& resolver,
     tflite::MicroAllocator* allocator, tflite::ErrorReporter* reporter,
-    bool use_current_thread, tflite::MicroProfiler* profiler)
+    bool use_current_thread, XCoreProfiler* profiler)
     : XCoreInterpreter(model, resolver, allocator, reporter, use_current_thread,
                        profiler),
       model_(model),

--- a/tensorflow/lite/micro/kernels/xcore/xcore_extended_interpreter.h
+++ b/tensorflow/lite/micro/kernels/xcore/xcore_extended_interpreter.h
@@ -5,6 +5,7 @@
 #include "tensorflow/lite/c/common.h"
 #include "tensorflow/lite/core/api/error_reporter.h"
 #include "tensorflow/lite/micro/kernels/xcore/xcore_interpreter.h"
+#include "tensorflow/lite/micro/kernels/xcore/xcore_profiler.h"
 
 namespace tflite {
 namespace micro {
@@ -48,14 +49,14 @@ class ExtendedXCoreInterpreter : public XCoreInterpreter {
                            uint8_t* arena, size_t arena_size,
                            tflite::ErrorReporter* reporter,
                            bool use_current_thread = true,
-                           tflite::MicroProfiler* profiler = nullptr);
+                           XCoreProfiler* profiler = nullptr);
 
   ExtendedXCoreInterpreter(const tflite::Model* model,
                            const tflite::MicroOpResolver& resolver,
                            tflite::MicroAllocator* allocator,
                            tflite::ErrorReporter* reporter,
                            bool use_current_thread = true,
-                           tflite::MicroProfiler* profiler = nullptr);
+                           XCoreProfiler* profiler = nullptr);
 
   size_t input_tensor_index(size_t input_index);
   size_t output_tensor_index(size_t output_index);

--- a/tensorflow/lite/micro/kernels/xcore/xcore_interpreter.cc
+++ b/tensorflow/lite/micro/kernels/xcore/xcore_interpreter.cc
@@ -5,27 +5,34 @@
 namespace tflite {
 namespace micro {
 namespace xcore {
-XCoreInterpreter::XCoreInterpreter(const tflite::Model* model,
-                                   const tflite::MicroOpResolver& resolver,
-                                   uint8_t* arena, size_t arena_size,
-                                   tflite::ErrorReporter* reporter,
-                                   bool use_current_thread,
-                                   tflite::MicroProfiler* profiler)
-    : tflite::MicroInterpreter(model, resolver, arena, arena_size, reporter,
-                               profiler),
-      dispatcher_(reporter, use_current_thread) {
-  SetDispatcher(&dispatcher_);
-}
 
 XCoreInterpreter::XCoreInterpreter(const tflite::Model* model,
                                    const tflite::MicroOpResolver& resolver,
                                    tflite::MicroAllocator* allocator,
                                    tflite::ErrorReporter* reporter,
                                    bool use_current_thread,
-                                   tflite::MicroProfiler* profiler)
+                                   XCoreProfiler* profiler)
     : tflite::MicroInterpreter(model, resolver, allocator, reporter, profiler),
       dispatcher_(reporter, use_current_thread) {
   SetDispatcher(&dispatcher_);
+  if (profiler) {
+    profiler->Init(allocator, operators_size());
+  }
+}
+
+XCoreInterpreter::XCoreInterpreter(const tflite::Model* model,
+                                   const tflite::MicroOpResolver& resolver,
+                                   uint8_t* arena, size_t arena_size,
+                                   tflite::ErrorReporter* reporter,
+                                   bool use_current_thread,
+                                   XCoreProfiler* profiler)
+    : XCoreInterpreter::XCoreInterpreter(
+          model, resolver, MicroAllocator::Create(arena, arena_size, reporter),
+          reporter, use_current_thread, profiler) {}
+
+TfLiteTensor* XCoreInterpreter::tensor(size_t tensor_index) {
+  auto ctx = context();
+  return ctx.GetTensor(&ctx, tensor_index);
 }
 
 }  // namespace xcore

--- a/tensorflow/lite/micro/kernels/xcore/xcore_interpreter.h
+++ b/tensorflow/lite/micro/kernels/xcore/xcore_interpreter.h
@@ -3,9 +3,9 @@
 #define XCORE_INTERPRETER_H_
 
 #include "tensorflow/lite/micro/kernels/xcore/xcore_dispatcher.h"
+#include "tensorflow/lite/micro/kernels/xcore/xcore_profiler.h"
 #include "tensorflow/lite/micro/micro_allocator.h"
 #include "tensorflow/lite/micro/micro_interpreter.h"
-#include "tensorflow/lite/micro/micro_profiler.h"
 
 namespace tflite {
 namespace micro {
@@ -17,14 +17,16 @@ class XCoreInterpreter : public tflite::MicroInterpreter {
                    const tflite::MicroOpResolver& resolver, uint8_t* arena,
                    size_t arena_size, tflite::ErrorReporter* reporter,
                    bool use_curent_thread = true,
-                   tflite::MicroProfiler* profiler = nullptr);
+                   XCoreProfiler* profiler = nullptr);
 
   XCoreInterpreter(const tflite::Model* model,
                    const tflite::MicroOpResolver& resolver,
                    tflite::MicroAllocator* allocator,
                    tflite::ErrorReporter* reporter,
                    bool use_current_thread = true,
-                   tflite::MicroProfiler* profiler = nullptr);
+                   XCoreProfiler* profiler = nullptr);
+
+  TfLiteTensor* tensor(size_t tensor_index);
 
  private:
   tflite::ops::micro::xcore::Dispatcher dispatcher_;

--- a/tensorflow/lite/micro/kernels/xcore/xcore_profiler.cc
+++ b/tensorflow/lite/micro/kernels/xcore/xcore_profiler.cc
@@ -8,27 +8,29 @@ namespace tflite {
 namespace micro {
 namespace xcore {
 
-XCoreProfiler::XCoreProfiler() : event_count_(0) {}
+void XCoreProfiler::Init(tflite::MicroAllocator* allocator,
+                         size_t max_event_count) {
+  max_event_count_ = max_event_count;
+  event_durations_ = static_cast<uint32_t*>(
+      allocator->AllocatePersistentBuffer(max_event_count * sizeof(uint32_t)));
+}
 
 uint32_t const* XCoreProfiler::GetEventDurations() { return event_durations_; }
 
-uint32_t XCoreProfiler::GetNumEvents() { return event_count_; }
+size_t XCoreProfiler::GetNumEvents() { return event_count_; }
 
 uint32_t XCoreProfiler::BeginEvent(const char* tag) {
-  event_start_time_ = tflite::GetCurrentTimeTicks();
-  TFLITE_DCHECK(tag != nullptr);
+  TFLITE_DCHECK(tag);
   event_tag_ = tag;
+  event_start_time_ = tflite::GetCurrentTimeTicks();
   return 0;
 }
 
 void XCoreProfiler::EndEvent(uint32_t event_handle) {
-  uint32_t event_duration;
   int32_t event_end_time = tflite::GetCurrentTimeTicks();
-  event_duration = event_end_time - event_start_time_;
-  if (event_count_ < XCORE_PROFILER_MAX_LEVELS) {
-    event_durations_[event_count_] = event_duration;
-    event_count_++;
-  }
+  event_count_ = event_count_ % max_event_count_;
+  // wrap if there are too many events
+  event_durations_[event_count_++] = event_end_time - event_start_time_;
 }
 
 }  // namespace xcore

--- a/tensorflow/lite/micro/kernels/xcore/xcore_profiler.cc
+++ b/tensorflow/lite/micro/kernels/xcore/xcore_profiler.cc
@@ -19,6 +19,8 @@ uint32_t const* XCoreProfiler::GetEventDurations() { return event_durations_; }
 
 size_t XCoreProfiler::GetNumEvents() { return event_count_; }
 
+void XCoreProfiler::ClearEvents() { event_count_ = 0; }
+
 uint32_t XCoreProfiler::BeginEvent(const char* tag) {
   TFLITE_DCHECK(tag);
   event_tag_ = tag;

--- a/tensorflow/lite/micro/kernels/xcore/xcore_profiler.h
+++ b/tensorflow/lite/micro/kernels/xcore/xcore_profiler.h
@@ -4,10 +4,11 @@
 #define XCORE_PROFILER_H_
 
 #include "tensorflow/lite/micro/compatibility.h"
+#include "tensorflow/lite/micro/micro_allocator.h"
 #include "tensorflow/lite/micro/micro_profiler.h"
 
-#if !defined(XCORE_PROFILER_MAX_LEVELS)
-#define XCORE_PROFILER_MAX_LEVELS (64)
+#if !defined(XCORE_PROFILER_DEFAULT_MAX_LEVELS)
+#define XCORE_PROFILER_DEFAULT_MAX_LEVELS (64)
 #endif
 
 namespace tflite {
@@ -16,8 +17,11 @@ namespace xcore {
 
 class XCoreProfiler : public tflite::MicroProfiler {
  public:
-  explicit XCoreProfiler();
+  explicit XCoreProfiler(){};
   ~XCoreProfiler() override = default;
+
+  void Init(tflite::MicroAllocator* allocator,
+            size_t max_event_count = XCORE_PROFILER_DEFAULT_MAX_LEVELS);
 
   uint32_t BeginEvent(const char* tag) override;
 
@@ -25,13 +29,14 @@ class XCoreProfiler : public tflite::MicroProfiler {
   void EndEvent(uint32_t event_handle) override;
 
   uint32_t const* GetEventDurations();
-  uint32_t GetNumEvents();
+  size_t GetNumEvents();
 
  private:
   const char* event_tag_;
   uint32_t event_start_time_;
-  uint32_t event_count_;
-  uint32_t event_durations_[XCORE_PROFILER_MAX_LEVELS];
+  size_t event_count_ = 0;
+  size_t max_event_count_ = 0;
+  uint32_t* event_durations_;
   TF_LITE_REMOVE_VIRTUAL_DELETE
 };
 

--- a/tensorflow/lite/micro/kernels/xcore/xcore_profiler.h
+++ b/tensorflow/lite/micro/kernels/xcore/xcore_profiler.h
@@ -23,6 +23,8 @@ class XCoreProfiler : public tflite::MicroProfiler {
   void Init(tflite::MicroAllocator* allocator,
             size_t max_event_count = XCORE_PROFILER_DEFAULT_MAX_LEVELS);
 
+  void ClearEvents();
+
   uint32_t BeginEvent(const char* tag) override;
 
   // Event_handle is ignored since TFLu does not support concurrent events.

--- a/tensorflow/lite/micro/xcore/micro_time.cc
+++ b/tensorflow/lite/micro/xcore/micro_time.cc
@@ -30,11 +30,6 @@ namespace tflite {
 
 int32_t ticks_per_second() { return PLATFORM_REFERENCE_HZ; }
 
-int32_t GetCurrentTimeTicks() {
-  hwtimer_t hwtimer = hwtimer_alloc();
-  int32_t ticks = hwtimer_get_time(hwtimer);
-  hwtimer_free(hwtimer);
-  return ticks;
-}
+int32_t GetCurrentTimeTicks() { return get_reference_time(); }
 
 }  // namespace tflite


### PR DESCRIPTION
This PR fixes a bug where the `XCoreInterpreter` would cause the arena to blow up due to incorrect usage of `interpreter->tensor(...)`. It also enables the `XCoreProfiler` to dynamically allocate arena space for the recorded timing data and correctly implements the `ClearEvents` method.